### PR TITLE
Addition of list mapping

### DIFF
--- a/gojq_test.go
+++ b/gojq_test.go
@@ -73,6 +73,40 @@ func TestParseJsonArray(t *testing.T) {
 	}
 }
 
+func TestMapJsonArray(t *testing.T) {
+	parserArray, err := NewStringQuery(jsonArray)
+	if err != nil {
+		t.Error(err)
+	}
+
+	var pass = []struct {
+		in string
+		ex []interface{}
+	}{
+		{"name", []interface{}{"elgs", "enny", "sam"}},
+	}
+
+	for _, v := range pass {
+		result, err := parserArray.Query(v.in)
+		if err != nil {
+			t.Error(err)
+		}
+		if list, ok := result.([]interface{}); ok {
+			if len(list) != len(v.ex) {
+				t.Error("Expected:", v.ex, "actual:", result)
+			}
+			for i, expected := range v.ex {
+				output := list[i]
+				if expected != output {
+					t.Error("Expected:", v.ex, "actual:", result)
+				}
+			}
+		} else {
+			t.Error("Expected:", v.ex, "actual:", result)
+		}
+	}
+}
+
 var jsonObj = `
 {
   "name": "sam",


### PR DESCRIPTION
This commit allows map queries on lists. Performing a map query on a list results in a new list, where each element is the element at the queried key of each object in the list that was queried. (mind the word-salad; I couldn't think of a better way to accurately explain it)

## Example
### JSON
```
{
  "test": [
    {
      "name": "elgs"
    },
    {
      "name": "enny"
    },
    {
      "name": "sam"
    }
  ]
}
```
### Code
```
input.Query(test.name) // ["elgs", "enny", "sam"]
```